### PR TITLE
Add floor transparency

### DIFF
--- a/src/lib/Generators.ts
+++ b/src/lib/Generators.ts
@@ -37,7 +37,8 @@ export class Generators {
     const floor_material = new MeshPhongMaterial({
       color: floor_color,
       wireframe: false,
-      transparent: false,
+      transparent: true,
+      opacity: 0.9,
       shininess: 0.0,
       specular: 0.0
     })


### PR DESCRIPTION
Some models/animations might appear below the floor level. Just added slight transparency to the floor to be able too see such animations.