### PR TITLE
Use a second render pass just for the skeleton to avoid z-fighting

### DIFF
--- a/src/Mesh2MotionEngine.ts
+++ b/src/Mesh2MotionEngine.ts
@@ -46,6 +46,7 @@ export class Mesh2MotionEngine {
 
   // has UI elements on the HTML page that we will reference/use
   public scene: Scene
+  public skeleton_scene: Scene
   public theme_manager: ThemeManager
   public ui: UI
   public load_model_step: StepLoadModel
@@ -76,12 +77,13 @@ export class Mesh2MotionEngine {
     this.animate = this.animate.bind(this)
 
     this.scene = new Scene()
+    this.skeleton_scene = new Scene()
     this.theme_manager = new ThemeManager()
     this.ui = UI.getInstance()
 
     // setting up steps
     this.load_model_step = new StepLoadModel()
-    this.load_skeleton_step = new StepLoadSkeleton(this.scene)
+    this.load_skeleton_step = new StepLoadSkeleton(this.scene, this.skeleton_scene)
     this.edit_skeleton_step = new StepEditSkeleton()
     this.weight_skin_step = new StepWeightSkin()
     this.animations_listing_step = new StepAnimationsListing(this.theme_manager)
@@ -178,12 +180,12 @@ export class Mesh2MotionEngine {
   public regenerate_skeleton_helper (new_skeleton: Skeleton, helper_name = 'Skeleton Helper'): void {
     // if skeleton helper exists...remove it
     if (this.skeleton_helper !== undefined) {
-      this.scene.remove(this.skeleton_helper)
+      this.skeleton_scene.remove(this.skeleton_helper)
     }
 
     this.skeleton_helper = new CustomSkeletonHelper(new_skeleton.bones[0], { linewidth: 4, color: 0x4e7d58 })
     this.skeleton_helper.name = helper_name
-    this.scene.add(this.skeleton_helper)
+    this.skeleton_scene.add(this.skeleton_helper)
   }
 
   public update_a_pose_options_visibility (): void {
@@ -262,7 +264,7 @@ export class Mesh2MotionEngine {
     else if (this.process_step === ProcessStep.LoadSkeleton) {
       // if skeleton helper existed because we are going back to this
       if (this.skeleton_helper !== undefined) {
-        this.scene.remove(this.skeleton_helper)
+        this.skeleton_scene.remove(this.skeleton_helper)
       }
 
       // need to change the texture display to normal material in
@@ -347,6 +349,7 @@ export class Mesh2MotionEngine {
     }
 
     this.renderer.render(this.scene, this.camera)
+    this.renderer.render(this.skeleton_scene, this.camera)
 
     // view helper
     this.view_helper.render(this.renderer) // updates current viewport

--- a/src/lib/processes/load-skeleton/OriginMarkerManager.ts
+++ b/src/lib/processes/load-skeleton/OriginMarkerManager.ts
@@ -2,15 +2,15 @@ import { type Object3D, Mesh, SphereGeometry, MeshBasicMaterial, type Scene, Gro
 
 const ORIGIN_MARKER_GROUP_NAME: string = 'origin_marker_group'
 
-export function add_origin_markers (root: Scene): void {
-  remove_origin_markers(root)
+export function add_origin_markers (root: Scene, skeleton_root: Scene): void {
+  remove_origin_markers(skeleton_root)
 
   // Create a group to hold all markers
-  let marker_group = root.getObjectByName(ORIGIN_MARKER_GROUP_NAME) as Group
+  let marker_group = skeleton_root.getObjectByName(ORIGIN_MARKER_GROUP_NAME) as Group
   if (!marker_group) {
     marker_group = new Group()
     marker_group.name = ORIGIN_MARKER_GROUP_NAME
-    root.add(marker_group)
+    skeleton_root.add(marker_group)
   }
 
   // with the root scene, there is a group called "Imported Model" that contains

--- a/src/lib/processes/load-skeleton/StepLoadSkeleton.ts
+++ b/src/lib/processes/load-skeleton/StepLoadSkeleton.ts
@@ -15,6 +15,7 @@ export class StepLoadSkeleton extends EventTarget {
 
   private _added_event_listeners: boolean = false
   private readonly _main_scene: Scene
+  private readonly _skeleton_scene: Scene
 
   // used to help scale animations later
   // this is useful since position keyframes will need to be scaled
@@ -44,9 +45,10 @@ export class StepLoadSkeleton extends EventTarget {
     return this.skeleton_scale_percentage
   }
 
-  constructor (main_scene: Scene) {
+  constructor (main_scene: Scene, skeleton_scene: Scene) {
     super()
     this._main_scene = main_scene
+    this._skeleton_scene = skeleton_scene
   }
 
   public begin (): void {
@@ -71,7 +73,7 @@ export class StepLoadSkeleton extends EventTarget {
     // when we come back to this step, there is a good chance we already selected a skeleton
     // so just use that and load the preview right when we enter this step
     if (!this.has_select_skeleton_ui_option()) {
-      add_preview_skeleton(this._main_scene, this.skeleton_file_path(),
+      add_preview_skeleton(this._skeleton_scene, this.skeleton_file_path(),
         this.hand_skeleton_type(), this.skeleton_scale_percentage).catch((err) => {
         console.error('error loading preview skeleton: ', err)
       })
@@ -81,7 +83,7 @@ export class StepLoadSkeleton extends EventTarget {
     this.toggle_ui_hand_skeleton_options()
 
     // add origin markers for debugging model loading issues
-    add_origin_markers(this._main_scene)
+    add_origin_markers(this._main_scene, this._skeleton_scene)
 
     // if there is a "select skeleton" option, disable proceeding
     // putting this check here helps us if we come back to this step later
@@ -93,12 +95,12 @@ export class StepLoadSkeleton extends EventTarget {
   }
 
   public regenerate_origin_markers (): void {
-    add_origin_markers(this._main_scene)
+    add_origin_markers(this._main_scene, this._skeleton_scene)
   }
 
   public dispose (): void {
-    remove_origin_markers(this._main_scene)
-    remove_preview_skeleton(this._main_scene)
+    remove_origin_markers(this._skeleton_scene)
+    remove_preview_skeleton(this._skeleton_scene)
   }
 
   private skeleton_file_path (): SkeletonType {
@@ -152,7 +154,7 @@ export class StepLoadSkeleton extends EventTarget {
         // load the preview skeleton
         // need to get the file name for the correct skeleton
         // we pass the skeleton scale in the case where we set a skeleton, change scale, then change the skeleton
-        add_preview_skeleton(this._main_scene, this.skeleton_file_path(), this.hand_skeleton_type(), this.skeleton_scale()).then(() => {
+        add_preview_skeleton(this._skeleton_scene, this.skeleton_file_path(), this.hand_skeleton_type(), this.skeleton_scale()).then(() => {
           // enable the ability to progress to next step
           this.allow_proceeding_to_next_step(true)
         }).catch((err) => {
@@ -177,7 +179,7 @@ export class StepLoadSkeleton extends EventTarget {
     this.ui.dom_hand_skeleton_selection?.addEventListener('change', () => {
       // rebuild the preview skeleton with the new hand skeleton type
       // make sure we keep existing scale if we made a change to that
-      add_preview_skeleton(this._main_scene, this.skeleton_file_path(), this.hand_skeleton_type(), this.skeleton_scale()).catch((err) => {
+      add_preview_skeleton(this._skeleton_scene, this.skeleton_file_path(), this.hand_skeleton_type(), this.skeleton_scale()).catch((err) => {
         console.error('error loading preview skeleton: ', err)
       })
     })
@@ -191,7 +193,7 @@ export class StepLoadSkeleton extends EventTarget {
       this.ui.dom_scale_skeleton_percentage_display!.textContent = display_value
 
       // re-add the preview skeleton with the new scale
-      add_preview_skeleton(this._main_scene, this.skeleton_file_path(), this.hand_skeleton_type(), this.skeleton_scale_percentage).catch((err) => {
+      add_preview_skeleton(this._skeleton_scene, this.skeleton_file_path(), this.hand_skeleton_type(), this.skeleton_scale_percentage).catch((err) => {
         console.error('error loading preview skeleton: ', err)
       })
     })


### PR DESCRIPTION
There is a skeleton rendering issue as mentioned in comment https://github.com/scottpetrovic/mesh2motion-app/pull/55#issuecomment-3419128406

The root cause is disabled depth test for the material (https://github.com/scottpetrovic/mesh2motion-app/blob/main/src/lib/CustomSkeletonHelper.ts#L45) which causes the skeleton's geometry being rendered in no specific order

The simplest solution is to render the skeleton in a separate render pass on top of the main scene as an overlay. We could probably change the skeleton render queue after transparent objects, but I am not a threejs expert...